### PR TITLE
Use "gcloud auth login" instead of "gcloud auth application-default login"

### DIFF
--- a/django_cloud_deploy/cloudlib/auth.py
+++ b/django_cloud_deploy/cloudlib/auth.py
@@ -15,8 +15,7 @@
 import os
 import subprocess
 
-import google.auth
-from google.auth import credentials
+from google.oauth2 import credentials
 
 
 class AuthClient(object):
@@ -39,12 +38,9 @@ class AuthClient(object):
         subprocess.check_call(
             command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-        # This will make google.auth.deafult() return the credentials object
-        # created by "gcloud auth login".
-        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = (
-            self._get_active_account_adc_path())
-        creds, _ = google.auth.default()
-        return creds
+        credentials_path = self._get_active_account_adc_path()
+        return credentials.Credentials.from_authorized_user_file(
+            credentials_path)
 
     @staticmethod
     def _get_active_account_adc_path() -> str:

--- a/django_cloud_deploy/cloudlib/auth.py
+++ b/django_cloud_deploy/cloudlib/auth.py
@@ -38,6 +38,9 @@ class AuthClient(object):
         command = ['gcloud', 'auth', 'login', '-q']
         subprocess.check_call(
             command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # This will make google.auth.deafult() return the credentials object
+        # created by "gcloud auth login".
         os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = (
             self._get_active_account_adc_path())
         creds, _ = google.auth.default()

--- a/django_cloud_deploy/cloudlib/auth.py
+++ b/django_cloud_deploy/cloudlib/auth.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 
 import google.auth
@@ -30,8 +31,40 @@ class AuthClient(object):
         Returns:
             Credentials Object
         """
-        command = ['gcloud', 'auth', 'application-default', 'login', '-q']
+
+        # We can not use "gcloud auth application-default login" here because
+        # we use "gcloud app deploy" to deploy a Django app to app-engine. It
+        # requires "gcloud auth login".
+        command = ['gcloud', 'auth', 'login', '-q']
         subprocess.check_call(
             command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = (
+            self._get_active_account_adc_path())
         creds, _ = google.auth.default()
         return creds
+
+    @staticmethod
+    def _get_active_account_adc_path() -> str:
+        """Get application default credentials path of the given account.
+
+        After we run "gcloud auth login", a credentials file for the login
+        account is created under
+        "~/.config/gcloud/legacy_credentials/<account>/adc.json". The accesses
+        given by "gcloud auth login" is a superset of
+        "gcloud auth application-default login".
+
+        Returns:
+            Absolute path of the application default credentials path of the
+            given account.
+        """
+        command = ['gcloud', 'info',
+                   '--format=value(config.paths.global_config_dir)']
+        gcloud_config_path = subprocess.check_output(
+            command, universal_newlines=True).rstrip()
+        command = ['gcloud', 'info', '--format=value(config.account)']
+        active_account = subprocess.check_output(
+            command, universal_newlines=True).rstrip()
+        # These hardcoded values are also hardcoded by gcloud.
+        return os.path.join(gcloud_config_path, 'legacy_credentials',
+                            active_account, 'adc.json')
+

--- a/django_cloud_deploy/cloudlib/auth.py
+++ b/django_cloud_deploy/cloudlib/auth.py
@@ -57,8 +57,9 @@ class AuthClient(object):
             Absolute path of the application default credentials path of the
             given account.
         """
-        command = ['gcloud', 'info',
-                   '--format=value(config.paths.global_config_dir)']
+        command = [
+            'gcloud', 'info', '--format=value(config.paths.global_config_dir)'
+        ]
         gcloud_config_path = subprocess.check_output(
             command, universal_newlines=True).rstrip()
         command = ['gcloud', 'info', '--format=value(config.account)']
@@ -67,4 +68,3 @@ class AuthClient(object):
         # These hardcoded values are also hardcoded by gcloud.
         return os.path.join(gcloud_config_path, 'legacy_credentials',
                             active_account, 'adc.json')
-


### PR DESCRIPTION
In #95, we removed "gcloud auth login" so that users only need to give access once. However, after that change the tool only works for GKE, because we use "gcloud app deploy" to deploy a Django app to GAE, which requires "gcloud auth login". So this change is made to fix that.

"gcloud auth login" will create a credentials file with the following accesses:

- View and manage your data across Google Cloud Platform services
- View and manage your Google Compute Engine resources
- View and manage your applications deployed on Google App Engine

"gcloud auth application-default login" will create a credentials file with the following accesses:
- View and manage your data across Google Cloud Platform services

So the accesses of credentials file created by "gcloud auth login" is a superset of credentials file created by "gcloud auth application-default login". So we can use the credentials file created by "gcloud auth login" as the application default credentials.