### PR TITLE
Increase socket timeout limit

### DIFF
--- a/django_cloud_deploy/cloudlib/static_content_serve.py
+++ b/django_cloud_deploy/cloudlib/static_content_serve.py
@@ -17,15 +17,11 @@ import os
 
 from django.conf import settings
 from django.core import management
+
 from googleapiclient import discovery
 from googleapiclient import errors
 from googleapiclient import http
-import httplib2
-
 from google.auth import credentials
-
-
-_HTTP_TIMEOUT_SEC = 120
 
 
 class StaticContentServeError(Exception):
@@ -45,12 +41,7 @@ class StaticContentServeClient(object):
 
     @classmethod
     def from_credentials(cls, credentials: credentials.Credentials):
-        return cls(
-            discovery.build(
-                'storage',
-                'v1',
-                credentials=credentials,
-                http=httplib2.Http(timeout=_HTTP_TIMEOUT_SEC)))
+        return cls(discovery.build('storage', 'v1', credentials=credentials))
 
     def create_bucket(self, project_id: str, bucket_name: str):
         """Create a Google Cloud Storage Bucket on the given project.

--- a/django_cloud_deploy/cloudlib/static_content_serve.py
+++ b/django_cloud_deploy/cloudlib/static_content_serve.py
@@ -17,11 +17,15 @@ import os
 
 from django.conf import settings
 from django.core import management
-
 from googleapiclient import discovery
 from googleapiclient import errors
 from googleapiclient import http
+import httplib2
+
 from google.auth import credentials
+
+
+_HTTP_TIMEOUT_SEC = 120
 
 
 class StaticContentServeError(Exception):
@@ -41,7 +45,12 @@ class StaticContentServeClient(object):
 
     @classmethod
     def from_credentials(cls, credentials: credentials.Credentials):
-        return cls(discovery.build('storage', 'v1', credentials=credentials))
+        return cls(
+            discovery.build(
+                'storage',
+                'v1',
+                credentials=credentials,
+                http=httplib2.Http(timeout=_HTTP_TIMEOUT_SEC)))
 
     def create_bucket(self, project_id: str, bucket_name: str):
         """Create a Google Cloud Storage Bucket on the given project.

--- a/django_cloud_deploy/workflow/__init__.py
+++ b/django_cloud_deploy/workflow/__init__.py
@@ -16,6 +16,7 @@
 import json
 import os
 import shutil
+import socket
 from typing import Any, Dict, List, Optional
 import webbrowser
 
@@ -34,6 +35,12 @@ from google.auth import credentials
 
 ProjectCreationMode = _project.CreationMode
 ProjectExistsError = _project.ProjectExistsError
+
+# Based on the source code of googleapiclient, the default timeout is 60
+# seconds. This might not be enough and sometimes causing socket timeout
+# exception.
+# See https://github.com/googleapis/google-api-python-client/issues/563
+socket.setdefaulttimeout(120)
 
 
 class InvalidConfigError(Exception):


### PR DESCRIPTION
Based on the discussions in #106, we might retry api calls to resolve the timeout issue as long as the apis are idempotent. 

Based on https://cloud.google.com/apis/docs/http#http_methods_verbs, POST methods are not idempotent. But the api which fails due to timeout is a POST method. See https://cloud.google.com/storage/docs/json_api/v1/objects/insert. So we cannot solve the problem by retrying api calls.

I decide to increase socket timeout limit. Based on the source code of googleapiclient, the default timeout is 60 seconds. See https://github.com/googleapis/google-api-python-client/blob/master/googleapiclient/http.py#L1786. I increase it to 120 seconds.

The idea behind this is similar with retrying api calls. If the api calls still raise a timeout exception after we increase the timeout limit, then we are quite sure there is something wrong with the service or user's network.

