### PR TITLE
Add progressbar for long steps.

### DIFF
--- a/django_cloud_deploy/cli/io.py
+++ b/django_cloud_deploy/cli/io.py
@@ -52,6 +52,7 @@ class _ProgressBar(object):
                 suffix.
         """
         self._expect_time = expect_time
+        self._tty = tty
 
         if tty:
             widgets = [
@@ -83,7 +84,8 @@ class _ProgressBar(object):
         """
         with self._bar_lock:
             # Go to the end of progress bar.
-            self._bar.update(self._expect_time * 2)
+            if self._tty:
+                self._bar.update(self._expect_time * 2)
             self._bar.finish()
 
     def _run(self):
@@ -98,7 +100,8 @@ class _ProgressBar(object):
                 # This part is to handle that case.
                 if self._bar.value == self._expect_time * 2:
                     return
-                self._bar.update(i)
+                if self._tty:
+                    self._bar.update(i)
             time.sleep(0.5)
 
 

--- a/django_cloud_deploy/cloudlib/project.py
+++ b/django_cloud_deploy/cloudlib/project.py
@@ -125,7 +125,8 @@ class ProjectClient(object):
 
     # The SLO is 30s at the 90th percentile:
     # https://cloud.google.com/resource-manager/reference/rest/v1/projects/create
-    @backoff.on_predicate(backoff.constant, max_tries=20, interval=3)
+    @backoff.on_predicate(backoff.constant, max_tries=20, interval=3,
+                          logger=None)
     def _confirm_project_creation(self, project_id: str) -> bool:
         return self.project_exists(project_id)
 

--- a/django_cloud_deploy/cloudlib/project.py
+++ b/django_cloud_deploy/cloudlib/project.py
@@ -125,8 +125,8 @@ class ProjectClient(object):
 
     # The SLO is 30s at the 90th percentile:
     # https://cloud.google.com/resource-manager/reference/rest/v1/projects/create
-    @backoff.on_predicate(backoff.constant, max_tries=20, interval=3,
-                          logger=None)
+    @backoff.on_predicate(
+        backoff.constant, max_tries=20, interval=3, logger=None)
     def _confirm_project_creation(self, project_id: str) -> bool:
         return self.project_exists(project_id)
 

--- a/django_cloud_deploy/nox.py
+++ b/django_cloud_deploy/nox.py
@@ -21,7 +21,7 @@ PACKAGES = [
     'oauth2client==4.1.2',
     'absl-py==0.3.0',
     'django==2.1',
-    'backoff==1.6.0',
+    'backoff==1.8.0',
     'jinja2==2.10',
     'google-cloud-resource-manager==0.28.1',
     'responses==0.9.0',

--- a/django_cloud_deploy/workflow/__init__.py
+++ b/django_cloud_deploy/workflow/__init__.py
@@ -254,8 +254,9 @@ class WorkflowManager(object):
                 self._generate_section_header(
                     8, 'Deployment (Take Up To 5 Minutes)',
                     self._TOTAL_NEW_STEPS))
-            app_url = self._deploygae_workflow.deploy_gae_app(
-                project_id, django_directory_path)
+            with self._console_io.progressbar(300, 'Deployment'):
+                app_url = self._deploygae_workflow.deploy_gae_app(
+                    project_id, django_directory_path)
 
         # Create configuration file to save information needed in "update"
         # command.

--- a/django_cloud_deploy/workflow/__init__.py
+++ b/django_cloud_deploy/workflow/__init__.py
@@ -156,19 +156,19 @@ class WorkflowManager(object):
 
         cloud_sql_proxy_port = portpicker.pick_unused_port()
 
-        self._console_io.tell(
-            '[1/{}]: Create GCP Project'.format(self._TOTAL_NEW_STEPS))
+        self._console_io.tell('[1/{}]: Create GCP Project'.format(
+            self._TOTAL_NEW_STEPS))
         self._project_workflow.create_project(project_name, project_id,
                                               project_creation_mode)
 
-        self._console_io.tell(
-            '[2/{}]: Billing Set Up'.format(self._TOTAL_NEW_STEPS))
+        self._console_io.tell('[2/{}]: Billing Set Up'.format(
+            self._TOTAL_NEW_STEPS))
         if not self._billing_client.check_billing_enabled(project_id):
             self._billing_client.enable_project_billing(project_id,
                                                         billing_account_name)
 
-        self._console_io.tell(
-            '[3/{}]: Django Source Generation'.format(self._TOTAL_NEW_STEPS))
+        self._console_io.tell('[3/{}]: Django Source Generation'.format(
+            self._TOTAL_NEW_STEPS))
 
         # Source generation requires service account ids.
         required_service_accounts = (
@@ -301,8 +301,8 @@ class WorkflowManager(object):
             django_directory_path, django_project_name, database_username,
             database_password, cloud_sql_proxy_port)
         with self._console_io.progressbar(
-            120, '[1/{}]: Database Migration'.format(
-                self._TOTAL_UPDATE_STEPS)):
+                120,
+                '[1/{}]: Database Migration'.format(self._TOTAL_UPDATE_STEPS)):
             self._database_workflow.migrate_database(
                 project_id=project_id,
                 instance_name=database_instance_name,
@@ -311,14 +311,14 @@ class WorkflowManager(object):
                 port=cloud_sql_proxy_port)
 
         with self._console_io.progressbar(
-            120, '[2/{}]: Static Content Update'.format(
-                self._TOTAL_UPDATE_STEPS)):
+                120, '[2/{}]: Static Content Update'.format(
+                    self._TOTAL_UPDATE_STEPS)):
             self._static_content_workflow.update_static_content(
                 cloud_storage_bucket_name, static_content_dir)
 
         with self._console_io.progressbar(
-            180, '[3/{}]: Update Deployment'.format(
-                self._TOTAL_UPDATE_STEPS)):
+                180,
+                '[3/{}]: Update Deployment'.format(self._TOTAL_UPDATE_STEPS)):
             if backend == 'gke':
                 app_url = self._deploygke_workflow.update_app_sync(
                     project_id, cluster_name, django_directory_path,

--- a/django_cloud_deploy/workflow/_deploygke.py
+++ b/django_cloud_deploy/workflow/_deploygke.py
@@ -169,7 +169,7 @@ class DeploygkeWorkflow(object):
         api = kubernetes.client.CoreV1Api(api_client)
         return self._try_get_ingress_url(api)
 
-    @backoff.on_predicate(backoff.constant, interval=0.5)
+    @backoff.on_predicate(backoff.constant, interval=0.5, logger=None)
     def _try_get_ingress_url(self, api: kubernetes.client.CoreV1Api) -> str:
         """Return Ingress url when service is ready."""
         items = api.list_service_for_all_namespaces().items
@@ -198,7 +198,7 @@ class DeploygkeWorkflow(object):
         label_selector = '='.join(['app', app_name])
         self._try_get_ready_replicas(api, label_selector)
 
-    @backoff.on_predicate(backoff.constant, interval=0.5)
+    @backoff.on_predicate(backoff.constant, interval=0.5, logger=None)
     def _try_get_ready_replicas(self,
                                 api: kubernetes.client.ExtensionsV1beta1Api,
                                 label_selector: str) -> int:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
     'urllib3==1.23',  # https://github.com/requests/requests/issues/4830
     'oauth2client>=4.1.2',
     'django>=2.1',
-    'backoff>=1.6.0',
+    'backoff>=1.8.0',
     'jinja2>=2.10',
     'google-cloud-resource-manager>=0.28.1',
     'docker>=3.4.1',


### PR DESCRIPTION
Output is like the follows:

```bash
**Step 1 of 8: Create GCP Project**


**Step 2 of 8: Billing Set Up**


**Step 3 of 8: Django Source Generation**


**Step 4 of 8: Database Set Up (Take Up To 5 Minutes)**

Database Set Up|█████████████████████████████████████████████| (Time:  0:03:39) 

**Step 5 of 8: Enable Services**

Enable Services|█████████████████████████████████████████████| (Time:  0:01:55) 

**Step 6 of 8: Static Content Serve Set Up (Take Up To 5 Minutes)**

Static Content Serve Set Up|█████████████████████████████████| (Time:  0:01:18) 

**Step 7 of 8: Create Service Account Necessary For Deployment**


**Step 8 of 8: Deployment (Take Up To 20 Minutes)**

Deployment|██████████████████████████████████████████████████| (Time:  0:05:31) 
Your app is running at http://35.203.166.234/.
```

I also updated backoff to 1.8.0 so that I can disable the logger of backoff. Otherwise the output of backoff's logger and progressbar will be mixed like the follows:

```bash
Deployment|███████████∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙| (ETA:   0:15:24) INFO:backoff:Backing off _try_get_ingress_url(...) for 0.3s ()
```