### PR TITLE
[WIP] Clean up GCP resources older than 2 hours when running presubmits.

### DIFF
--- a/django_cloud_deploy/nox.py
+++ b/django_cloud_deploy/nox.py
@@ -38,6 +38,7 @@ PACKAGES = [
     'google-cloud-logging==1.8.0',
     'progressbar2>=3.38.0',
     'portpicker==1.2.0',
+    'iso8601==0.1.12',
 ]
 
 

--- a/django_cloud_deploy/tests/cleanup/resource_cleanup.py
+++ b/django_cloud_deploy/tests/cleanup/resource_cleanup.py
@@ -1,0 +1,93 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Versconsolen 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITconsoleNS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissconsolens and
+# limitatconsolens under the License.
+"""End to end test for create and deploy new project."""
+
+import datetime
+import shutil
+import tempfile
+import types
+import unittest
+import urllib.parse
+
+from django_cloud_deploy.tests.lib import test_base
+from django_cloud_deploy.tests.lib import utils
+import iso8601
+import googleapiclient
+from googleapiclient import discovery
+
+
+class GCPResourceCleanUp(test_base.ResourceCleanUp):
+    """Clean up GCP resources more than 2 hours old."""
+
+    MAX_DIFF = datetime.timedelta(hours=2)
+
+    def _should_delete(self, create_time: str) -> bool:
+        """Return whether this resource should be deleted."""
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        # create_time is in rfc3339 format.
+        # See https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster
+        # For example, '2019-02-21T00:41:26+00:00'
+        try:
+            create_time_object = iso8601.parse_date(create_time)
+        except iso8601.iso8601.ParseError:
+            # If the time format is valid, then return False. This might mean
+            # some unexpected errors in creation. We want to keep the resource
+            # for debugging.
+            return False
+        diff = now - create_time_object
+        return diff > self.MAX_DIFF
+
+    def delete_expired_clusters(self):
+        container_service = discovery.build(
+            'container', 'v1', credentials=self.credentials)
+        request = container_service.projects().zones().clusters().list(
+            projectId=self.project_id, zone=self.zone)
+        response = request.execute()
+        for cluster in response.get('clusters', []):
+            if self._should_delete(cluster.get('createTime', '')):
+                self._delete_cluster(
+                    cluster.get('name', ''), container_service)
+                print('Deleted cluster: ', cluster.get('name'))
+
+    def delete_expired_buckets(self):
+        storage_service = discovery.build(
+            'storage', 'v1', credentials=self.credentials)
+        request = storage_service.buckets().list(project=self.project_id)
+        response = request.execute()
+        for item in response.get('items', []):
+            if self._should_delete(item.get('timeCreated', '')):
+                self._delete_bucket(item.get('name', ''), storage_service)
+
+    def delete_expired_sql_instances(self):
+        sqladmin_service = discovery.build(
+            'sqladmin', 'v1beta4', credentials=self.credentials)
+        request = sqladmin_service.instances().list(projectId=self.project_id)
+        response = request.execute()
+        for instance in response.get('items', []):
+            if self._should_delete(instance.get('createTime', '')):
+                # The returned object does not contain creation time
+                self._clean_up_sql_instance(
+                    instance.get('serverCaCert').get('createTime'),
+                    sqladmin_service)
+
+    def delete_expired_service_accounts(self):
+        iam_service = discovery.build(
+            'iam', 'v1', credentials=self.credentials)
+
+    def test_resoucr_cleanup(self):
+        """This is not a test, but cleans up test related resources."""
+        self.delete_expired_clusters()
+        self.delete_expired_buckets()
+        self.delete_expired_sql_instances()

--- a/django_cloud_deploy/tests/e2e/gke_deploy_test.py
+++ b/django_cloud_deploy/tests/e2e/gke_deploy_test.py
@@ -31,7 +31,7 @@ from selenium import webdriver
 from selenium.webdriver.chrome import options
 
 
-class GKEDeployAndUpdateE2ETest(test_base.ResourceCleanUpTest):
+class GKEDeployAndUpdateE2ETest(test_base.ResourceCleanUp):
     """End to end test for create and deploy new project."""
 
     _CLOUDSQL_ROLES = ('roles/cloudsql.client', 'roles/cloudsql.editor',

--- a/django_cloud_deploy/tests/integration/cloudlib_test.py
+++ b/django_cloud_deploy/tests/integration/cloudlib_test.py
@@ -22,7 +22,7 @@ from django_cloud_deploy.tests.lib import utils
 
 
 class StaticContentServeClientIntegrationTest(test_base.DjangoFileGeneratorTest,
-                                              test_base.ResourceCleanUpTest):
+                                              test_base.ResourceCleanUp):
     """Integration test for django_gke.cloudlib.static_content_serve."""
 
     def setUp(self):
@@ -39,7 +39,7 @@ class StaticContentServeClientIntegrationTest(test_base.DjangoFileGeneratorTest,
                     self.project_id, bucket_name)
 
 
-class ServiceAccountClientIntegrationTest(test_base.ResourceCleanUpTest):
+class ServiceAccountClientIntegrationTest(test_base.ResourceCleanUp):
     """Integration test for cloudlib.service_account."""
 
     _ROLES = ('roles/cloudsql.client', 'roles/cloudsql.editor',
@@ -63,7 +63,7 @@ class ServiceAccountClientIntegrationTest(test_base.ResourceCleanUpTest):
 
 
 class DatabaseClientIntegrationTest(test_base.DjangoFileGeneratorTest,
-                                    test_base.ResourceCleanUpTest):
+                                    test_base.ResourceCleanUp):
     """Integration test for django_cloud_deploy.cloudlib.database."""
 
     def setUp(self):
@@ -82,7 +82,7 @@ class DatabaseClientIntegrationTest(test_base.DjangoFileGeneratorTest,
                     self.project_id, self.instance_name, self.database_name)
 
 
-class ContainerClientIntegrationTest(test_base.ResourceCleanUpTest):
+class ContainerClientIntegrationTest(test_base.ResourceCleanUp):
     """Integration test for django_cloud_deploy.cloudlib.container."""
 
     def setUp(self):

--- a/django_cloud_deploy/tests/integration/workflow_test.py
+++ b/django_cloud_deploy/tests/integration/workflow_test.py
@@ -31,7 +31,7 @@ from googleapiclient import errors
 import requests
 
 
-class EnableServiceWorkflowIntegrationTest(test_base.ResourceCleanUpTest):
+class EnableServiceWorkflowIntegrationTest(test_base.ResourceCleanUp):
     """Integration test for django_cloud_deploy.workflow._enable_service."""
 
     # Google drive api is not already enabled on the GCP project for integration
@@ -62,7 +62,7 @@ class EnableServiceWorkflowIntegrationTest(test_base.ResourceCleanUpTest):
 
 
 class ServiceAccountKeyGenerationWorkflowIntegrationTest(
-        test_base.ResourceCleanUpTest):
+        test_base.ResourceCleanUp):
     """Integration test for django_cloud_deploy.workflow._service_account."""
 
     ROLES = ('roles/cloudsql.client', 'roles/cloudsql.editor',
@@ -130,7 +130,7 @@ class ServiceAccountKeyGenerationWorkflowIntegrationTest(
 
 
 class DeploygkeWorkflowIntegrationTest(test_base.DjangoFileGeneratorTest,
-                                       test_base.ResourceCleanUpTest):
+                                       test_base.ResourceCleanUp):
     """Integration test for django_cloud_deploy.workflow._deploygke."""
 
     def setUp(self):
@@ -219,7 +219,7 @@ class ProjectWorkflowIntegrationTest(test_base.BaseTest):
 
 
 class StaticContentServeWorkflowIntegrationTest(
-        test_base.DjangoFileGeneratorTest, test_base.ResourceCleanUpTest):
+        test_base.DjangoFileGeneratorTest, test_base.ResourceCleanUp):
     """Integration test for django_gke.workflow._static_content_serve."""
 
     def setUp(self):
@@ -241,7 +241,7 @@ class StaticContentServeWorkflowIntegrationTest(
 
 
 class DatabaseWorkflowIntegrationTest(test_base.DjangoFileGeneratorTest,
-                                      test_base.ResourceCleanUpTest):
+                                      test_base.ResourceCleanUp):
     """Integration test for django_cloud_deploy.workflow._database."""
 
     def setUp(self):


### PR DESCRIPTION
Fixes #243, #234 

Sometimes the GCP resources are not correctly deleted. For example, the user pressed "Ctrl+C", job is cancelled on CircleCI, or the api call for resource deletion just failed. More and more resources are left on GCP project.

#243 fails because there are lots of service accounts created but not deleted. When running test for service account creation, we use the following api to check whether the newly created service account exist:

https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts/list

This api will not return all service accounts by default. If there are too many service accounts, this api call will return the first ~20 service accounts and a page token, and we can get the remaining service accounts by providing the page token in api call. 

I assumed this api call will return all service accounts. This is why #243 happen. 
@enriquejosepadilla after this PR is in, the "Service account cannot be found" error in test should disappear.