### PR TITLE
Fix integration test about database reusing

### DIFF
--- a/django_cloud_deploy/cloudlib/database.py
+++ b/django_cloud_deploy/cloudlib/database.py
@@ -146,6 +146,11 @@ class DatabaseClient(object):
             project=project_id, instance=instance, database=database)
         try:
             response = request.execute()
+
+            # This means the database already exist. In this case we do not need
+            # to create the same database again.
+            if 'name' in response:
+                return
         except errors.HttpError as e:
             if e.resp.status == 404:
                 # The database we would like to create does not exist yet. This

--- a/django_cloud_deploy/cloudlib/database.py
+++ b/django_cloud_deploy/cloudlib/database.py
@@ -143,9 +143,7 @@ class DatabaseClient(object):
         # See:
         # https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/insert
         request = self._sqladmin_service.databases().get(
-            project=project_id,
-            instance=instance,
-            database=database)
+            project=project_id, instance=instance, database=database)
         try:
             response = request.execute()
         except errors.HttpError as e:

--- a/django_cloud_deploy/cloudlib/database.py
+++ b/django_cloud_deploy/cloudlib/database.py
@@ -146,11 +146,6 @@ class DatabaseClient(object):
             project=project_id, instance=instance, database=database)
         try:
             response = request.execute()
-
-            # This means the database already exist. In this case we do not need
-            # to create the same database again.
-            if 'name' in response:
-                return
         except errors.HttpError as e:
             if e.resp.status == 404:
                 # The database we would like to create does not exist yet. This
@@ -160,6 +155,10 @@ class DatabaseClient(object):
                 raise DatabaseError(
                     ('Unexpected response when getting status of database '
                      '{!r}: [{!r}]').format(database, response))
+        # This means the database already exist. In this case we do not need
+        # to create the same database again.
+        if 'name' in response:
+            return
         request = self._sqladmin_service.databases().insert(
             project=project_id,
             instance=instance,

--- a/django_cloud_deploy/cloudlib/database.py
+++ b/django_cloud_deploy/cloudlib/database.py
@@ -142,6 +142,21 @@ class DatabaseClient(object):
         """
         # See:
         # https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/insert
+        request = self._sqladmin_service.databases().get(
+            project=project_id,
+            instance=instance,
+            database=database)
+        try:
+            response = request.execute()
+        except errors.HttpError as e:
+            if e.resp.status == 404:
+                # The database we would like to create does not exist yet. This
+                # is what we want.
+                pass
+            else:
+                raise DatabaseError(
+                    ('Unexpected response when getting status of database '
+                     '{!r}: [{!r}]').format(database, response))
         request = self._sqladmin_service.databases().insert(
             project=project_id,
             instance=instance,

--- a/django_cloud_deploy/cloudlib/database.py
+++ b/django_cloud_deploy/cloudlib/database.py
@@ -144,6 +144,7 @@ class DatabaseClient(object):
         # https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/databases/insert
         request = self._sqladmin_service.databases().get(
             project=project_id, instance=instance, database=database)
+        response = []
         try:
             response = request.execute()
         except errors.HttpError as e:


### PR DESCRIPTION
The test did not fail before. This might be caused by some changes in GCP backend.

Now we will check whether the database already exist or not. The tool only try to create the database when that database does not exist.