### PR TITLE
Checks permission for existing projects.

### DIFF
--- a/django_cloud_deploy/cli/prompt.py
+++ b/django_cloud_deploy/cli/prompt.py
@@ -631,7 +631,8 @@ class GoogleExistingProjectId(TemplatePrompt):
         # Regex will catch user:email@email.com
         # and serviceAccount:email@email.com
         # which are currently the only cases
-        active_account = re.escape(r'\w+:{}'.format(active_account))
+        active_account = re.escape(active_account)
+        active_account = r'\w+:{}'.format(active_account)
         if re.search(active_account, ' '.join(owners)):
             return True
 

--- a/django_cloud_deploy/cli/prompt.py
+++ b/django_cloud_deploy/cli/prompt.py
@@ -613,7 +613,7 @@ class GoogleExistingProjectId(TemplatePrompt):
             active_account: Account that is logged in on gcloud cli.
         """
         # The user must have logged in
-        assert active_account != ''
+        assert active_account not in ['', None], "User must log in via gcloud"
 
         permissions = self.project_client.get_project_permissions(project_id)
         owner_permission = list(
@@ -628,7 +628,10 @@ class GoogleExistingProjectId(TemplatePrompt):
         if editor_permission:
             editors = editor_permission[0].get('members', [])
 
-        active_account = re.escape(active_account)
+        # Regex will catch user:email@email.com
+        # and serviceAccount:email@email.com
+        # which are currently the only cases
+        active_account = re.escape(r'\w+:{}'.format(active_account))
         if re.search(active_account, ' '.join(owners)):
             return True
 

--- a/django_cloud_deploy/cli/prompt.py
+++ b/django_cloud_deploy/cli/prompt.py
@@ -630,14 +630,15 @@ class GoogleExistingProjectId(TemplatePrompt):
             editors = editor_permission[0].get('members', [])
 
         active_account = 'user:{}'.format(active_account)
+        service_account = 'serviceAccount:{}'.format(active_account)
 
-        if active_account in owners:
+        if active_account in owners or service_account in owners:
             return True
 
         if backend == 'gae':  # User needs to be in owner to deploy in GAE.
             return False
 
-        if active_account in editors:
+        if active_account in editors or service_account in editors:
             return True
 
         return False

--- a/django_cloud_deploy/cli/prompt.py
+++ b/django_cloud_deploy/cli/prompt.py
@@ -616,17 +616,17 @@ class GoogleExistingProjectId(TemplatePrompt):
         assert active_account != ''
 
         permissions = self.project_client.get_project_permissions(project_id)
-        owner_permission = filter(lambda d: d.get('role') == 'roles/owner',
-                                  permissions)
-        editor_permission = filter(lambda d: d.get('role') == 'roles/editor',
-                                   permissions)
+        owner_permission = list(
+            filter(lambda d: d.get('role') == 'roles/owner', permissions))
+        editor_permission = list(
+            filter(lambda d: d.get('role') == 'roles/editor', permissions))
 
         owners = []
         editors = []
         if owner_permission:
-            owners = next(owner_permission).get('members', [])
+            owners = owner_permission[0].get('members', [])
         if editor_permission:
-            editors = next(editor_permission).get('members', [])
+            editors = editor_permission[0].get('members', [])
 
         active_account = 'user:{}'.format(active_account)
 

--- a/django_cloud_deploy/cli/prompt.py
+++ b/django_cloud_deploy/cli/prompt.py
@@ -14,7 +14,6 @@
 """Prompts the user for information e.g. project name."""
 
 import abc
-import copy
 import enum
 import functools
 import os.path
@@ -347,7 +346,7 @@ class StringTemplatePrompt(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step,
                                      args.get(self.PARAMETER, None),
                                      self._validate):
@@ -429,7 +428,7 @@ class GoogleProjectName(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
 
         project_id = args.get('project_id', None)
         mode = args.get('project_creation_mode', None)
@@ -490,7 +489,7 @@ class GoogleNewProjectId(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step,
                                      args.get(self.PARAMETER, None),
                                      self._validate):
@@ -559,7 +558,7 @@ class GoogleExistingProjectId(TemplatePrompt):
         Returns: A Copy of args + the new parameter collected.
         """
 
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         backend = args.get('backend')
         validate = functools.partial(self._validate, backend,
                                      self.active_account)
@@ -629,16 +628,14 @@ class GoogleExistingProjectId(TemplatePrompt):
         if editor_permission:
             editors = editor_permission[0].get('members', [])
 
-        active_account = 'user:{}'.format(active_account)
-        service_account = 'serviceAccount:{}'.format(active_account)
-
-        if active_account in owners or service_account in owners:
+        active_account = re.escape(active_account)
+        if re.search(active_account, ' '.join(owners)):
             return True
 
         if backend == 'gae':  # User needs to be in owner to deploy in GAE.
             return False
 
-        if active_account in editors or service_account in editors:
+        if re.search(active_account, ' '.join(editors)):
             return True
 
         return False
@@ -663,7 +660,7 @@ class CredentialsPrompt(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step,
                                      args.get(self.PARAMETER), lambda x: x):
             return new_args
@@ -774,7 +771,7 @@ class BillingPrompt(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step, args.get(self.PARAMETER),
                                      self._validate):
             return new_args
@@ -843,7 +840,7 @@ class PostgresPasswordPrompt(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step, args.get(self.PARAMETER),
                                      self._validate):
             return new_args
@@ -896,7 +893,7 @@ class DjangoFilesystemPath(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
 
         if self._is_valid_passed_arg(console, step,
                                      args.get(self.PARAMETER), lambda x: x):
@@ -947,7 +944,7 @@ class DjangoFilesystemPathUpdate(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step, args.get(self.PARAMETER),
                                      self._validate):
             return new_args
@@ -1094,7 +1091,7 @@ class DjangoSuperuserPasswordPrompt(TemplatePrompt):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if self._is_valid_passed_arg(console, step, args.get(self.PARAMETER),
                                      self._validate):
             return new_args
@@ -1201,7 +1198,7 @@ class RootPrompt(object):
 
         Returns: A Copy of args + the new parameter collected.
         """
-        new_args = copy.deepcopy(args)
+        new_args = dict(args)
         if new_args.get('use_existing_project', False):
             new_args['project_creation_mode'] = (
                 workflow.ProjectCreationMode.MUST_EXIST)

--- a/django_cloud_deploy/cloudlib/project.py
+++ b/django_cloud_deploy/cloudlib/project.py
@@ -16,8 +16,7 @@
 See https://gcloud-python.readthedocs.io/en/latest/resource-manager/api.html
 """
 
-import subprocess
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import backoff
 import google_auth_httplib2
@@ -80,6 +79,17 @@ class ProjectClient(object):
             return request.execute()
         except errors.HttpError as e:
             raise e
+
+    def get_project_permissions(self, project_id: str) -> List[Dict[str, Any]]:
+        """Returns a list of permissions from the project"""
+        request = self._cloudresourcemanager_service.projects().getIamPolicy(
+            resource=project_id, body={})
+        try:
+            response = request.execute()
+            return response.get('bindings', [])
+        except errors.HttpError as e:
+            if e.resp.status in [403, 404]:
+                return []
 
     def _is_google_account(self) -> bool:
         """Returns whether the user logged in with a google.com account."""

--- a/django_cloud_deploy/tests/unit/cli/prompt_test.py
+++ b/django_cloud_deploy/tests/unit/cli/prompt_test.py
@@ -245,7 +245,9 @@ class ProjectIdPromptTest(parameterized.TestCase):
     def setUpClass(cls):
         creds = mock.Mock(credentials.Credentials, authSpec=True)
         project_client = project.ProjectClient.from_credentials(creds)
-        cls.project_id_prompt = prompt.GoogleProjectId(project_client)
+        active_account = 'email@email.com'
+        cls.project_id_prompt = prompt.GoogleProjectId(project_client,
+                                                       active_account)
 
     def test_new_prompt(self):
         test_io = io.TestIO()

--- a/django_cloud_deploy/tests/unit/cli/prompt_test.py
+++ b/django_cloud_deploy/tests/unit/cli/prompt_test.py
@@ -39,23 +39,15 @@ _FAKE_PROJECT_RESPONSE = {
     }
 }
 
-_FAKE_PERMISSIONS_RESPONSE_OWNER = {
-    'bindings': [
-        {
-            'role': 'roles/owner',
-            'members': ['email@email.com']
-        }
-    ]
-}
+_FAKE_PERMISSIONS_RESPONSE_OWNER = [{
+    'role': 'roles/owner',
+    'members': ['user:email@email.com']
+}]
 
-_FAKE_PERMISSIONS_RESPONSE_EDITOR = {
-    'bindings': [
-        {
-            'role': 'roles/editor',
-            'members': ['email@email.com']
-        }
-    ]
-}
+_FAKE_PERMISSIONS_RESPONSE_EDITOR = [{
+    'role': 'roles/editor',
+    'members': ['user:email@email.com']
+}]
 
 
 class GoogleCloudProjectNamePromptTest(absltest.TestCase):
@@ -301,7 +293,8 @@ class ProjectIdPromptTest(parameterized.TestCase):
         args = {
             'backend': 'gae',
             'project_creation_mode': workflow.ProjectCreationMode.MUST_EXIST,
-            'project_id': 'projectid-123'
+            'project_id': 'projectid-123',
+            'use_existing_project': True
         }
         test_io.answers.append('projectid-123')
         args = self.project_id_prompt.prompt(test_io, '[1/2]', args)
@@ -321,15 +314,13 @@ class ProjectIdPromptTest(parameterized.TestCase):
         args = {
             'backend': 'gae',
             'project_creation_mode': workflow.ProjectCreationMode.MUST_EXIST,
-            'project_id': 'projectid-123'
+            'project_id': 'projectid-123',
+            'use_existing_project': True
         }
         test_io.answers.append('projectid-123')
 
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(SystemExit):
             self.project_id_prompt.prompt(test_io, '[1/2]', args)
-            msg = 'User must be a Project Owner to deploy on GAE'
-            self.assertEquals(msg, str(e))
-
 
     def test_prompt_default_project_name(self):
         test_io = io.TestIO()


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/django-cloud-deploy/issues/205

User study would provide users with projects they are not owner of GAE project, or they were not editors for GKE. This checks to make sure and crashes early.

Only applies to existing-projects.