### PR TITLE
Fix prompt flag message

### DIFF
--- a/django_cloud_deploy/cli/prompt.py
+++ b/django_cloud_deploy/cli/prompt.py
@@ -374,7 +374,6 @@ class StringTemplatePrompt(TemplatePrompt):
 class GoogleProjectName(TemplatePrompt):
 
     PARAMETER = 'project_name'
-
     MESSAGE = '{} Enter a Google Cloud Platform project name'
 
     def __init__(self, project_client: project.ProjectClient):


### PR DESCRIPTION
#375 

It looks like this now 

```
(venv) epad:django_cloud_deploy$ django-cloud-deploy new --project-name=django-no-admin --project-path=/usr/local/google/home/epad/Projects/django-no-admin --database-password=dbpassword --django-project-name=djangonoadmin --django-superuser-login=admin --django-superuser-email=test@test.com --django-superuser-password=adminpassword --billing-account-name=billingAccounts/0135D3-2564D9-xxxxx --django-app-name=djangonoadminapp
[1/11] In order to deploy your application, you must allow Django Deploy to access your Google account.
You have logged in with account [epad@google.com]. Do you want to use it? [Y/n]: 
[2/11] Enter a Google Cloud Platform Project id
or leave blank to use [django-no-admin-617007]: 
[3/11] Enter a Google Cloud Platform project name: django-no-admin
[4/11] Enter a billing account: billingAccounts/0135D3-2564D9-xxxxx
[5/11] Enter a password for the default database user "postgres": dbpassword
[6/11] Enter a new directory path to store project source: epad/Projects/django-no-admin
[7/11] Enter a Django project name or leave blank to use: djangonoadmin
[8/11] Enter a Django app name or leave blank to use: djangonoadminapp
[9/11] Enter a Django superuser login name: admin
[10/11] Enter a password for the Django superuser: adminpassword
[11/11] Enter an email adress for the Django superuser or leave blank to use: test@test.com
```